### PR TITLE
商品詳細機能の完成

### DIFF
--- a/src/main/java/com/example/controller/ShowItemDetailController.java
+++ b/src/main/java/com/example/controller/ShowItemDetailController.java
@@ -1,0 +1,36 @@
+package com.example.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.example.domain.Item;
+import com.example.service.ShowItemDetailService;
+
+/**
+ * 商品詳細を表示する操作をするコントローラ.
+ * 
+ * @author okahikari
+ * 
+ */
+@Controller
+@RequestMapping("/item")
+public class ShowItemDetailController {
+	
+	@Autowired
+	private ShowItemDetailService showItemDetailService;
+	
+	/**
+	 * 商品詳細画面を表示する.
+	 * 
+	 * @param id 商品ID
+	 * @return 商品詳細画面
+	 */
+	@RequestMapping("/")
+	public String showDetail(Integer id, Model model) {
+		Item item = showItemDetailService.searchById(id);
+		model.addAttribute("item", item);
+		return "item_detail";
+	}
+}

--- a/src/main/java/com/example/repository/ItemRepository.java
+++ b/src/main/java/com/example/repository/ItemRepository.java
@@ -55,4 +55,17 @@ public class ItemRepository {
 		}
 		return itemList;
 	}
+	
+	/**
+	 * 商品をIDから取得する.
+	 * 
+	 * @param id 商品ID
+	 * @return 商品情報
+	 */
+	public Item findById(Integer id) {
+		StringBuilder sql = new StringBuilder();
+		sql.append("SELECT id, name, description, price_m, price_l, image_path, deleted FROM items WHERE id = :id;");
+		SqlParameterSource param = new MapSqlParameterSource().addValue("id", id);
+		return template.queryForObject(sql.toString(), param, ITEM_ROW_MAPPER);
+	}
 }

--- a/src/main/java/com/example/repository/ToppingRepository.java
+++ b/src/main/java/com/example/repository/ToppingRepository.java
@@ -1,0 +1,38 @@
+package com.example.repository;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.example.domain.Topping;
+
+/**
+ * toppingsテーブルを操作するリポジトリ.
+ * 
+ * @author okahikari
+ * 
+ */
+@Repository
+public class ToppingRepository {
+	
+	@Autowired
+	private NamedParameterJdbcTemplate template;
+	
+	private static final RowMapper<Topping> TOPPING_ROW_MAPPER
+	= new BeanPropertyRowMapper<>(Topping.class);
+	
+	/**
+	 * 全トッピング情報を取得する.
+	 * 
+	 * @return 全トッピング情報
+	 */
+	public List<Topping> findAll(){
+		StringBuilder sql = new StringBuilder();
+		sql.append("SELECT id, name, price_m, price_l FROM toppings;");
+		return template.query(sql.toString(), TOPPING_ROW_MAPPER);
+	}
+}

--- a/src/main/java/com/example/service/ShowItemDetailService.java
+++ b/src/main/java/com/example/service/ShowItemDetailService.java
@@ -1,0 +1,42 @@
+package com.example.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.domain.Item;
+import com.example.domain.Topping;
+import com.example.repository.ItemRepository;
+import com.example.repository.ToppingRepository;
+
+/**
+ * 商品詳細表示時に業務処理をするサービスクラス.
+ * 
+ * @author okahikari
+ * 
+ */
+@Service
+@Transactional
+public class ShowItemDetailService {
+	
+	@Autowired
+	private ItemRepository itemRepository;
+	
+	@Autowired
+	private ToppingRepository toppingRepository;
+	
+	/**
+	 * IDから商品情報を取得する.
+	 * 
+	 * @param id 商品ID
+	 * @return 商品情報
+	 */
+	public Item searchById(Integer id) {
+		Item item = itemRepository.findById(id);
+		List<Topping> toppingList = toppingRepository.findAll();
+		item.setToppingList(toppingList);
+		return item;
+	}
+}

--- a/src/main/resources/templates/item_detail.html
+++ b/src/main/resources/templates/item_detail.html
@@ -5,8 +5,8 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>ピザ屋のネット注文</title>
-<link href="../static/css/bootstrap.css" rel="stylesheet">
-<link href="../static/css/piza.css" rel="stylesheet">
+<link href="../static/css/bootstrap.css" th:href="@{/css/bootstrap.css}" rel="stylesheet">
+<link href="../static/css/piza.css" th:href="@{/css/piza.css}" rel="stylesheet">
 <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
@@ -52,14 +52,14 @@
 				<h3 class="text-center">商品詳細</h3>
 				<div class="row">
 					<div class="col-xs-5">
-						<img src="../static/img_pizza/1.jpg" class="img-responsive img-rounded item-img-center">
+						<img src="../static/img_pizza/1.jpg" th:src="@{/img_curry/} + ${item.id} + .jpg" class="img-responsive img-rounded item-img-center">
 					</div>
 
 					<div class="col-xs-5">
 						<div class="bs-component">
-							<h4>じゃがバターベーコン</h4> <br>
+							<h4 th:text="${item.name}">じゃがバターベーコン</h4> <br>
 							<br>
-							<p>マイルドな味付けのカレーに大きくカットしたポテトをのせた、バターとチーズの風味が食欲をそそるお子様でも楽しめる商品です。</p>
+							<p th:text="${item.description}">マイルドな味付けのカレーに大きくカットしたポテトをのせた、バターとチーズの風味が食欲をそそるお子様でも楽しめる商品です。</p>
 						</div>
 					</div>
 				</div><br>
@@ -72,14 +72,12 @@
 								</div>
 								<div class="col-sm-12">
 									<label class="radio-inline">
-										<input type="radio"
-											name="responsibleCompany" checked="checked">
-										<span class="price">&nbsp;М&nbsp;</span>&nbsp;&nbsp;1,380円(税抜)
+										<input type="radio" name="responsibleCompany" checked="checked">
+										<span class="price">&nbsp;М&nbsp;</span>&nbsp;&nbsp;<span th:text="${item.priceM}">1,380</span>円(税抜)
 									</label>
 									<label class="radio-inline">
-										<input type="radio"
-											name="responsibleCompany">
-										<span class="price">&nbsp;Ｌ</span>&nbsp;&nbsp;2,380円(税抜)
+										<input type="radio" name="responsibleCompany">
+										<span class="price">&nbsp;Ｌ</span>&nbsp;&nbsp;<span th:text="${item.priceL}">2,380</span>円(税抜)
 									</label>
 								</div>
 							</div>
@@ -97,30 +95,9 @@
 										<span>&nbsp;Ｌ</span>&nbsp;&nbsp;300円(税抜)
 									</label>
 								</div>
-								<div class="col-sm-12">
+								<div class="col-sm-6" th:each="topping : ${item.toppingList}">
 									<label class="checkbox-inline">
-										<input type="checkbox" value="">オニオン
-									</label>
-									<label class="checkbox-inline">
-										<input type="checkbox" value="">チーズ
-									</label>
-									<label class="checkbox-inline">
-										<input type="checkbox" value="">ピーマン
-									</label>
-									<label class="checkbox-inline">
-										<input type="checkbox" value="">ロースハム
-									</label><br>
-									<label class="checkbox-inline">
-										<input type="checkbox" value="">ほうれん草
-									</label>
-									<label class="checkbox-inline">
-										<input type="checkbox" value="">ぺパロに
-									</label>
-									<label class="checkbox-inline">
-										<input type="checkbox" value="">グリルナス
-									</label>
-									<label class="checkbox-inline">
-										<input type="checkbox" value="">あらびきソーセージ
+										<input type="checkbox" value="" th:text="${topping.name}">
 									</label>
 								</div>
 							</div>
@@ -133,9 +110,8 @@
 							<div class="row">
 								<div class="col-xs-5 col-sm-5">
 									<label for="">数量:</label>
-									<label class="control-label"
-										style="color: red" for="inputError">数量を選択してください</label> <select
-										name="area" class="form-control">
+									<label class="control-label" style="color: red" for="inputError">数量を選択してください</label>
+									<select name="area" class="form-control">
 										<option value="1">1</option>
 										<option value="2">2</option>
 										<option value="3">3</option>
@@ -166,8 +142,7 @@
 					<div class="col-xs-offset-2 col-xs-3">
 						<div class="form-group">
 							<p>
-								<input class="form-control btn btn-warning btn-block"
-									type="submit" value="カートに入れる">
+								<input class="form-control btn btn-warning btn-block" type="submit" value="カートに入れる">
 							</p>
 
 						</div>

--- a/src/main/resources/templates/item_list_curry.html
+++ b/src/main/resources/templates/item_list_curry.html
@@ -78,11 +78,11 @@
 					<tbody class="box">
 						<tr th:each="item : ${itemList}">
 							<th>
-								<a href="item_detail.html">
+								<a href="item_detail.html" th:href="@{/item/?id=} + ${item.id}">
 									<img src="../static/img_curry/1.jpg" class="img-responsive img-rounded 
 									item-img-center" width="299" height="600" th:src="@{/img_curry/} + ${item.imagePath}">
 								</a><br>
-								<a href="item_detail.html" th:text="${item.name}">じゃがバターベーコン</a><br>
+								<a href="item_detail.html" th:href="@{/item/?id=} + ${item.id}" th:text="${item.name}">じゃがバターベーコン</a><br>
 								<span class="price">&nbsp;М&nbsp;</span>&nbsp;&nbsp;<span th:text="${item.priceM}"></span>円(税抜)<br>
 								<span class="price">&nbsp;Ｌ</span>&nbsp;&nbsp;<span th:text="${item.priceL}"></span>円(税抜)<br>
 							</th>


### PR DESCRIPTION
## 変更の概要

* 商品詳細が表示される機能の完成

## やったこと

* [x] 商品詳細を表示する
* [x] 商品一覧ページの商品名に商品詳細へ遷移するリンクの付与
* [ ] 自動合計金額反映機能

## 変更内容

* ItemRepositoryの追加
→findByIdメソッドの追加

* ToppingRepositoryの新規作成
→findAllメソッドの追加

* ShowItemDetailServiceの新規作成
→showDetailメソッドの追加

* ShowItemDetailControllerの新規作成
→showDetailメソッドの追加

* item_list_curry.htmlの変更
→商品詳細へ遷移するリンクの設置

* item_detail.htmlの変更
→商品IDから取得した商品の表示

## 影響範囲

* ItemRepository
* item_list_curry.html
* item_detail.html

## どうやるのか

* 使い方
* URL'/item/all'で商品一覧画面を表示した後、商品の画像または商品名のリンクを押す
